### PR TITLE
Make iTerm2.9 and up always open a new window.

### DIFF
--- a/custom_iterm_script_iterm_2.9.applescript
+++ b/custom_iterm_script_iterm_2.9.applescript
@@ -12,18 +12,9 @@ on alfred_script(q)
 			on run {q}
 				tell application \":Applications:iTerm.app\"
 					activate
-					try
-						select first window
-						set onlywindow to true
-					on error
-						create window with default profile
-						select first window
-						set onlywindow to true
-					end try
+					create window with default profile
+					select first window
 					tell the first window
-						if onlywindow is false then
-							create tab with default profile
-						end if
 						tell current session to write text q
 					end tell
 				end tell

--- a/custom_iterm_script_iterm_3.1.1.applescript
+++ b/custom_iterm_script_iterm_3.1.1.applescript
@@ -7,18 +7,9 @@ on alfred_script(q)
 			on run {q}
 				tell application \"iTerm\"
 					activate
-					try
-						select first window
-						set onlywindow to true
-					on error
-						create window with default profile
-						select first window
-						set onlywindow to true
-					end try
+					create window with default profile
+					select first window
 					tell the first window
-						if onlywindow is false then
-							create tab with default profile
-						end if
 						tell current session to write text q
 					end tell
 				end tell


### PR DESCRIPTION
Tested this on Build 3.2.5beta1.

**I did not test this on other iTerm versions.**

This commit changes intended behaviour (I think) so feel free to delete it.