### PR TITLE
custom_iterm_script_iterm_3.1.1.applescript: open tab when there are windows

### DIFF
--- a/custom_iterm_script_iterm_3.1.1.applescript
+++ b/custom_iterm_script_iterm_3.1.1.applescript
@@ -9,14 +9,14 @@ on alfred_script(q)
 					activate
 					try
 						select first window
-						set onlywindow to true
+						set nowindows to false
 					on error
 						create window with default profile
 						select first window
-						set onlywindow to true
+						set nowindows to true
 					end try
 					tell the first window
-						if onlywindow is false then
+						if nowindows is false then
 							create tab with default profile
 						end if
 						tell current session to write text q


### PR DESCRIPTION
@stuartcryan @sineld The current solution uses the current tab if there is one, which can mess up the content that is already there.

The code is buggy because `onlywindow` (now `nowindows` to be more explicit) was never set to `false` in any case, so that check would never fire. The `2.9` version suffers from the same issue, but I doubt that one is worth maintaining.